### PR TITLE
Standardize error logging with the Error Manager

### DIFF
--- a/laptop/gui/statusframe.py
+++ b/laptop/gui/statusframe.py
@@ -61,8 +61,8 @@ class StatusFrame(tk.Frame):
         self.color = highestcolor
         self.currentlevel = highestlevel
         self.status.config(bg=highestcolor)
-        self.flash = highestflash
-        if self.flash:
+        if not self.flash and highestflash:
+            self.flash = True
             self.parent.after(500, self.flash_status, 0)
 
         return clearedError

--- a/mainRPI.py
+++ b/mainRPI.py
@@ -1,11 +1,13 @@
 import logging
 import multiprocessing
+import time
 
 from rpi.logging.listener import LoggingListener
 from rpi.network.server import Server
 from rpi.sensors.pressure import Pressure
 from rpi.sensors.thermometer import ThermoList
 from rpi.sensors.vibration import Vibration
+from shared.customlogging.errormanager import ErrorManager
 from shared.customlogging.handler import CustomQueueHandler
 
 if __name__ == '__main__':
@@ -28,10 +30,16 @@ if __name__ == '__main__':
         p.start()
         processes[processClass] = p
 
+    em = ErrorManager(__name__)
+
     while True:
+        time.sleep(5)
         for processClass, process in processes.items():
             if not process.is_alive():
-                root.error('The process for {} exited! Restarting it...'.format(processClass.__name__))
+                em.error('The process for {} exited! Trying to restart it...'.format(processClass.__name__),
+                         processClass.__name__)
                 p = processClass()
                 p.start()
                 processes[processClass] = p
+            else:
+                em.resolve('{} started successfully'.format(processClass.__name__), processClass.__name__, False)

--- a/shared/customlogging/errormanager.py
+++ b/shared/customlogging/errormanager.py
@@ -3,6 +3,12 @@ import random
 import time
 
 
+class ErrorData:
+    def __init__(self, error_level):
+        self.last_raised = time.time()
+        self.error_level = error_level
+
+
 class ErrorManager:
     """
     Class to help simplify the error logging and management
@@ -20,8 +26,7 @@ class ErrorManager:
         disabled, i.e. the error must be solved before being allowed to be sent again.
         """
 
-        # Stores the raised errors. The dictionary keys are the error_id, and the values are the last time the error was
-        # raised
+        # Stores the raised errors. The dictionary keys are the error_id, and the values is an object of type ErrorData
         self.errors = dict()
 
         self.logger = logging.getLogger(logger_name)
@@ -39,13 +44,14 @@ class ErrorManager:
         """
         if error_id not in self.errors:
             return True
-        elif self.debounce_time != 0 and (time.time() - self.errors[error_id]) >= self.debounce_time:
+        elif self.debounce_time != 0 and (time.time() - self.errors[error_id].last_raised) >= self.debounce_time:
             return True
 
         return False
 
     def __send_error(self, message, error_id, error_level):
-        self.errors[error_id] = (error_level, time.time())
+        self.errors[error_id] = ErrorData(error_level)
+
         if error_level == logging.WARNING:
             self.logger.warning(message, extra={'errorID': error_id + self.id_append})
         else:

--- a/shared/customlogging/errormanager.py
+++ b/shared/customlogging/errormanager.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import time
 
 
 class ErrorManager:
@@ -7,50 +8,65 @@ class ErrorManager:
     Class to help simplify the error logging and management
 
     The main feature of this class is that errors and warning are kept track of and will not be logged again until they
-    are 'resolved'. The main use of this is to avoid spamming the laptop with a lot of the same error messages.
+    are 'resolved'. The main use of this is to avoid spamming the laptop with a lot of the same error messages. Other
+    features are supported like only sending allow sending an error again after a set amount of time passed.
     """
 
-    def __init__(self, logger_name):
+    def __init__(self, logger_name, debounce_time=0):
         """
         :param logger_name: The name under which the logger should be created
+        :param debounce_time: Specifies the number of seconds to wait before allowing a message with the same
+        error_id to be sent again, even if it has not been resolved. If this is set to 0, this functionality is
+        disabled, i.e. the error must be solved before being allowed to be sent again.
         """
-        self.errors = set()
+
+        # Stores the raised errors. The dictionary keys are the error_id, and the values are the last time the error was
+        # raised
+        self.errors = dict()
+
         self.logger = logging.getLogger(logger_name)
+        self.debounce_time = debounce_time
 
         # Append this number to the error_id in the functions bellow.
         # This way, different error managers can use the same error_id and not have a collision
         self.id_append = str(random.randint(0, 100000))
 
-    def __check_error(self, error_id):
+    def __allow_logging(self, error_id):
         """
-        Checks if the error_id was already, and if not, track it by adding it to the self.errors set
+        Performs some checks to see if we should allow this error to be logged. If needed, it will also add the error_id
+        to the self.errors to keep track of it.
         :param error_id: The unique id of the error
         :return: If error_id was already raised
         """
         if error_id not in self.errors:
-            self.errors.add(error_id)
-            return False
+            self.errors[error_id] = time.time()
+            return True
+        elif self.debounce_time != 0 and (time.time() - self.errors[error_id]) >= self.debounce_time:
+            self.errors[error_id] = time.time()
+            return True
 
-        return True
+        return False
 
     def error(self, message, error_id):
         """
-        Logs an error. Multiple call to this function or warning() with the same error_id will not log the error again
-        until the error is resolved by calling the function resolve().
+        Logs an error. Multiple call to this function or warning() with the same error_id will only log the error again
+        if the debounce_time is not 0. Resolving the error by calling resolve() resets the error state, i.e.
+        calling this function again will resend the error.
         :param message: A simple message describing the error
         :param error_id: A unique id to identify this error
         """
-        if not self.__check_error(error_id):
+        if self.__allow_logging(error_id):
             self.logger.error(message, extra={'errorID': error_id + self.id_append})
 
     def warning(self, message, error_id):
         """
-        Logs an warning. Multiple call to this function or error() with the same error_id will not log the error again
-        until the error is resolved by calling the function resolve().
+        Logs an warning. Multiple call to this function or error() with the same error_id will only log the error
+        again if the debounce_time is not 0. Resolving the error by calling resolve() resets the error state, i.e.
+        calling this function again will resend the error.
         :param message: A simple message describing the error
         :param error_id: A unique id to identify this error
         """
-        if not self.__check_error(error_id):
+        if self.__allow_logging(error_id):
             self.logger.warning(message, extra={'errorID': error_id + self.id_append})
 
     def resolve(self, message, error_id, always_send=True):
@@ -61,7 +77,7 @@ class ErrorManager:
         :param always_send: If True, the message will be sent even if no error have been raised before
         """
         if error_id in self.errors:
-            self.errors.remove(error_id)
+            self.errors.pop(error_id)
             logging.info(message, extra={'errorID': error_id + self.id_append})
         elif always_send:
             logging.info(message, extra={'errorID': error_id + self.id_append})

--- a/shared/customlogging/errormanager.py
+++ b/shared/customlogging/errormanager.py
@@ -1,0 +1,62 @@
+import logging
+
+
+class ErrorManager:
+    """
+    Class to help simplify the error logging and management
+
+    The main feature of this class is that errors and warning are kept track of and will not be logged again until they
+    are 'resolved'. The main use of this is to avoid spamming the laptop with a lot of the same error messages.
+    """
+
+    def __init__(self, logger_name):
+        """
+        :param logger_name: The name under which the logger should be created
+        """
+        self.errors = set()
+        self.logger = logging.getLogger(logger_name)
+
+    def __check_error(self, error_id):
+        """
+        Checks if the error_id was already, and if not, track it by adding it to the self.errors set
+        :param error_id: The unique id of the error
+        :return: If error_id was already raised
+        """
+        if error_id not in self.errors:
+            self.errors.add(error_id)
+            return False
+
+        return True
+
+    def error(self, message, error_id):
+        """
+        Logs an error. Multiple call to this function or warning() with the same error_id will not log the error again
+        until the error is resolved by calling the function resolve().
+        :param message: A simple message describing the error
+        :param error_id: A unique id to identify this error
+        """
+        if not self.__check_error(error_id):
+            self.logger.error(message, extra={'errorID': error_id})
+
+    def warning(self, message, error_id):
+        """
+        Logs an warning. Multiple call to this function or error() with the same error_id will not log the error again
+        until the error is resolved by calling the function resolve().
+        :param message: A simple message describing the error
+        :param error_id: A unique id to identify this error
+        """
+        if not self.__check_error(error_id):
+            self.logger.warning(message, extra={'errorID': error_id})
+
+    def resolve(self, message, error_id, always_send=True):
+        """
+        Marks an error as resolved. The message is sent as an informational message.
+        :param message: A simple message describing the resolved error
+        :param error_id: A unique id to identify this error
+        :param always_send: If True, the message will be sent even if no error have been raised before
+        """
+        if error_id in self.errors:
+            self.errors.remove(error_id)
+            logging.info(message, extra={'errorID': error_id})
+        elif always_send:
+            logging.info(message, extra={'errorID': error_id})

--- a/shared/customlogging/errormanager.py
+++ b/shared/customlogging/errormanager.py
@@ -1,4 +1,5 @@
 import logging
+import random
 
 
 class ErrorManager:
@@ -15,6 +16,10 @@ class ErrorManager:
         """
         self.errors = set()
         self.logger = logging.getLogger(logger_name)
+
+        # Append this number to the error_id in the functions bellow.
+        # This way, different error managers can use the same error_id and not have a collision
+        self.id_append = str(random.randint(0, 100000))
 
     def __check_error(self, error_id):
         """
@@ -36,7 +41,7 @@ class ErrorManager:
         :param error_id: A unique id to identify this error
         """
         if not self.__check_error(error_id):
-            self.logger.error(message, extra={'errorID': error_id})
+            self.logger.error(message, extra={'errorID': error_id + self.id_append})
 
     def warning(self, message, error_id):
         """
@@ -46,7 +51,7 @@ class ErrorManager:
         :param error_id: A unique id to identify this error
         """
         if not self.__check_error(error_id):
-            self.logger.warning(message, extra={'errorID': error_id})
+            self.logger.warning(message, extra={'errorID': error_id + self.id_append})
 
     def resolve(self, message, error_id, always_send=True):
         """
@@ -57,6 +62,6 @@ class ErrorManager:
         """
         if error_id in self.errors:
             self.errors.remove(error_id)
-            logging.info(message, extra={'errorID': error_id})
+            logging.info(message, extra={'errorID': error_id + self.id_append})
         elif always_send:
-            logging.info(message, extra={'errorID': error_id})
+            logging.info(message, extra={'errorID': error_id + self.id_append})


### PR DESCRIPTION
This pull request introduces the `Error Manager`. The goal of this class is to make it easy to prevent spamming the laptop with repeated identical error messages. There is three main way to use it:

  - Create an instance of `ErrorManager` and use the `warning()`, `error()`, and `resolve()` methods. If any errors are raised with `warning()` or `error()`, the only way to send them again to the logs is to call `resolve()` on that error.
  - Specify a debounce time when creating an instance of `ErrorManager`. If this is done, multiple calls to `warning()` and `error()` can send again the error message after the specified amount of time has passed
  - Create an instance of `ErrorManager` and use the `escalate()` and `resolve()` methods. `escalate()` is similar to `warning()`, however, after a specified amount of time, if escalate() is called again,  the error will be sent again but as an *error type* instead of as a *warning type*.

This pull request is not yet ready to merge. There is still a need to test more this class to make sure it works as intended. Also, places that could benefit from using this class or that were using their own custom made way to do the same thing should be refactored to use the `ErrorManager` instead.